### PR TITLE
Make better use of C++11 features

### DIFF
--- a/dbmse/.gitignore
+++ b/dbmse/.gitignore
@@ -1,0 +1,3 @@
+*.exe
+*.o
+engine/demo/demo

--- a/dbmse/engine/demo/Makefile
+++ b/dbmse/engine/demo/Makefile
@@ -2,12 +2,16 @@ CC=g++
 #CXXFLAGS=-std=c++11
 CXXFLAGS=-std=c++11 -g -O0
 SRC=../interface/interface.cpp pgetnextnode.cpp pselectnode.cpp pjoinnode.cpp demo.cpp
+HDR=../interface/interface.h ../interface/basics.h pgetnextnode.h pjoinnode.h pselectnode.h
 OBJ=../interface/interface.o pgetnextnode.o pselectnode.o pjoinnode.o demo.o
 
 all: demo
 
 valgrind: demo
 	valgrind --leak-check=full --track-origins=yes ./demo
+
+restyle-all:
+	astyle --suffix=none --options=../../style.astylerc $(SRC) $(HDR)
 
 demo: $(OBJ)
 	$(CC) $(OBJ) $(CXXFLAGS) -o $@

--- a/dbmse/engine/demo/demo.cpp
+++ b/dbmse/engine/demo/demo.cpp
@@ -28,17 +28,17 @@
 #include "pjoinnode.h"
 
 // Here be rewriter and optimizer
-PResultNode* QueryFactory(LAbstractNode* node){
+PResultNode* QueryFactory(LAbstractNode* node) {
   // As of now, we handle only SELECTs with 0 predicates
   // Implementing conjunctive predicates is your homework
-  if(dynamic_cast<LSelectNode*>(node) != NULL){
+  if (dynamic_cast<LSelectNode*>(node) != NULL) {
     LSelectNode* tmp = (LSelectNode*)node;
     std::vector<Predicate> p;
     return new PSelectNode(tmp, p);
-  }else
-  // Also, only one join is possible
-  // Supporting more joins is also your (future) homework
-    if(dynamic_cast<LJoinNode*>(node) != NULL){
+  } else
+    // Also, only one join is possible
+    // Supporting more joins is also your (future) homework
+    if (dynamic_cast<LJoinNode*>(node) != NULL) {
 
       LSelectNode* tmp = (LSelectNode*)(node->GetRight());
       std::vector<Predicate> p;
@@ -48,21 +48,21 @@ PResultNode* QueryFactory(LAbstractNode* node){
       PSelectNode* lres = new PSelectNode(tmp2, p);
 
       return new PJoinNode(lres, rres, node);
-  }else
-  return NULL;
+    } else
+      return NULL;
 
 }
 
-void ExecuteQuery(PResultNode* query){
+void ExecuteQuery(PResultNode* query) {
   std::tuple<ErrCode, std::vector<Value>> res;
   res = query->GetRecord();
   ErrCode ec = std::get<0>(res);
   std::vector<Value> vals = std::get<1>(res);
-  while(ec == EC_OK){
-    for (int i = 0; i < query->GetAttrNum(); i++){
-      if(vals[i].vtype == VT_INT)
+  while (ec == EC_OK) {
+    for (int i = 0; i < query->GetAttrNum(); i++) {
+      if (vals[i].vtype == VT_INT)
         std::cout << vals[i].vint << " ";
-      else if(vals[i].vtype == VT_STRING)
+      else if (vals[i].vtype == VT_STRING)
         std::cout << vals[i].vstr << " ";
     }
     printf("\n");
@@ -73,7 +73,7 @@ void ExecuteQuery(PResultNode* query){
 
 }
 
-int main(){
+int main() {
   {
     std::cout << "Starting demo" << std::endl;
     std::cout << "Query1: plain select" << std::endl;

--- a/dbmse/engine/demo/demo.cpp
+++ b/dbmse/engine/demo/demo.cpp
@@ -44,12 +44,12 @@ std::unique_ptr<PResultNode> QueryFactory(LAbstractNode* node) {
 
       LSelectNode* tmp = (LSelectNode*)(node->GetRight());
       std::vector<Predicate> p;
-      PSelectNode* rres = new PSelectNode(tmp, p);
+      std::unique_ptr<PSelectNode> rres(new PSelectNode(tmp, p));
 
       LSelectNode* tmp2 = (LSelectNode*)(node->GetLeft());
-      PSelectNode* lres = new PSelectNode(tmp2, p);
+      std::unique_ptr<PSelectNode> lres(new PSelectNode(tmp2, p));
 
-      return std::unique_ptr<PResultNode>(new PJoinNode(lres, rres, node));
+      return std::unique_ptr<PResultNode>(std::unique_ptr<PJoinNode>(new PJoinNode(std::move(lres), std::move(rres), node)));
     } else
       return nullptr;
 

--- a/dbmse/engine/demo/pgetnextnode.cpp
+++ b/dbmse/engine/demo/pgetnextnode.cpp
@@ -21,24 +21,24 @@
 
 #include "pgetnextnode.h"
 
-PGetNextNode::PGetNextNode(): PResultNode(NULL, NULL, NULL){
+PGetNextNode::PGetNextNode(): PResultNode(NULL, NULL, NULL) {
   Initialize();
 }
 
 PGetNextNode::PGetNextNode(PResultNode* left, PResultNode* right, LAbstractNode* source):
-                                                                  PResultNode(left, right, source){
+  PResultNode(left, right, source) {
   Initialize();
 }
 
-void PGetNextNode::Initialize(){
+void PGetNextNode::Initialize() {
   return;
 }
 
-std::vector<std::vector<Value>> PGetNextNode::GetNext(){
+std::vector<std::vector<Value>> PGetNextNode::GetNext() {
   return std::vector<std::vector<Value>>();
 }
 
-int PGetNextNode::GetAttrNum(){
+int PGetNextNode::GetAttrNum() {
   return prototype->fieldNames.size();
 }
 

--- a/dbmse/engine/demo/pgetnextnode.cpp
+++ b/dbmse/engine/demo/pgetnextnode.cpp
@@ -18,6 +18,7 @@
 // 0.2: first public release
 
 #include <tuple>
+#include <utility>
 
 #include "pgetnextnode.h"
 
@@ -25,8 +26,8 @@ PGetNextNode::PGetNextNode(): PResultNode(nullptr, nullptr, nullptr) {
   Initialize();
 }
 
-PGetNextNode::PGetNextNode(PResultNode* left, PResultNode* right, LAbstractNode* source):
-  PResultNode(left, right, source) {
+PGetNextNode::PGetNextNode(std::unique_ptr<PResultNode> left_, std::unique_ptr<PResultNode> right_, LAbstractNode* source)
+  : PResultNode(std::move(left_), std::move(right_), source) {
   Initialize();
 }
 

--- a/dbmse/engine/demo/pgetnextnode.cpp
+++ b/dbmse/engine/demo/pgetnextnode.cpp
@@ -21,7 +21,7 @@
 
 #include "pgetnextnode.h"
 
-PGetNextNode::PGetNextNode(): PResultNode(NULL, NULL, NULL) {
+PGetNextNode::PGetNextNode(): PResultNode(nullptr, nullptr, nullptr) {
   Initialize();
 }
 

--- a/dbmse/engine/demo/pgetnextnode.h
+++ b/dbmse/engine/demo/pgetnextnode.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include "../interface/interface.h"
 
-class PGetNextNode : public PResultNode{
+class PGetNextNode : public PResultNode {
   public:
     PGetNextNode();
     PGetNextNode(PResultNode* left, PResultNode* right, LAbstractNode* p);

--- a/dbmse/engine/demo/pgetnextnode.h
+++ b/dbmse/engine/demo/pgetnextnode.h
@@ -32,7 +32,7 @@ class PGetNextNode : public PResultNode {
     // getting access to data
     virtual void Initialize();
     // get number of attributes
-    virtual int GetAttrNum();
+    int GetAttrNum() override;
   protected:
 
   private:

--- a/dbmse/engine/demo/pgetnextnode.h
+++ b/dbmse/engine/demo/pgetnextnode.h
@@ -20,12 +20,13 @@
 #ifndef PGETNEXTNODE_H
 #define PGETNEXTNODE_H
 #include <vector>
+#include <memory>
 #include "../interface/interface.h"
 
 class PGetNextNode : public PResultNode {
   public:
     PGetNextNode();
-    PGetNextNode(PResultNode* left, PResultNode* right, LAbstractNode* p);
+    PGetNextNode(std::unique_ptr<PResultNode> left, std::unique_ptr<PResultNode> right, LAbstractNode* p);
     // internal way to transfer data
     virtual std::vector<std::vector<Value>> GetNext();
     // getting access to data

--- a/dbmse/engine/demo/pjoinnode.cpp
+++ b/dbmse/engine/demo/pjoinnode.cpp
@@ -19,18 +19,14 @@
 
 #include<cstddef>
 #include<algorithm>
+#include<utility>
 
 #include "pjoinnode.h"
 
-PJoinNode::PJoinNode(PGetNextNode* left, PGetNextNode* right,
-                     LAbstractNode* p): PGetNextNode(left, right, p) {
+PJoinNode::PJoinNode(std::unique_ptr<PGetNextNode> left_, std::unique_ptr<PGetNextNode> right_,
+                     LAbstractNode* p): PGetNextNode(std::move(left_), std::move(right_), p) {
   pos = 0;
   Initialize();
-}
-
-PJoinNode::~PJoinNode() {
-  delete left;
-  delete right;
 }
 
 std::vector<std::vector<Value>> PJoinNode::GetNext() {
@@ -38,8 +34,8 @@ std::vector<std::vector<Value>> PJoinNode::GetNext() {
 }
 
 void PJoinNode::Initialize() {
-  PGetNextNode* l = (PGetNextNode*)left;
-  PGetNextNode* r = (PGetNextNode*)right;
+  PGetNextNode* l = (PGetNextNode*)left.get();
+  PGetNextNode* r = (PGetNextNode*)right.get();
   LAbstractNode* lp = l->prototype;
   LAbstractNode* rp = r->prototype;
   std::vector<std::vector<std::string>> ln = lp->fieldNames;

--- a/dbmse/engine/demo/pjoinnode.cpp
+++ b/dbmse/engine/demo/pjoinnode.cpp
@@ -23,21 +23,21 @@
 #include "pjoinnode.h"
 
 PJoinNode::PJoinNode(PGetNextNode* left, PGetNextNode* right,
-                     LAbstractNode* p): PGetNextNode(left, right, p){
+                     LAbstractNode* p): PGetNextNode(left, right, p) {
   pos = 0;
   Initialize();
 }
 
-PJoinNode::~PJoinNode(){
+PJoinNode::~PJoinNode() {
   delete left;
   delete right;
 }
 
-std::vector<std::vector<Value>> PJoinNode::GetNext(){
+std::vector<std::vector<Value>> PJoinNode::GetNext() {
   return data;
 }
 
-void PJoinNode::Initialize(){
+void PJoinNode::Initialize() {
   PGetNextNode* l = (PGetNextNode*)left;
   PGetNextNode* r = (PGetNextNode*)right;
   LAbstractNode* lp = l->prototype;
@@ -50,11 +50,11 @@ void PJoinNode::Initialize(){
   LAbstractNode* p = prototype;
   std::ptrdiff_t lpos, rpos;
 
-  for (int i = 0; i < lp->fieldNames.size(); i++){
+  for (int i = 0; i < lp->fieldNames.size(); i++) {
     std::ptrdiff_t lpos1 = std::find(ln[i].begin(), ln[i].end(), ((LJoinNode*)prototype)->offset1) - ln[i].begin();
     std::ptrdiff_t lpos2 = std::find(ln[i].begin(), ln[i].end(), ((LJoinNode*)prototype)->offset2) - ln[i].begin();
 
-    if(lpos1 <= ln.size() || lpos1 <= ln.size()){
+    if (lpos1 <= ln.size() || lpos1 <= ln.size()) {
       if (lpos1 < lpos2)
         lpos = lpos1;
       else
@@ -63,11 +63,11 @@ void PJoinNode::Initialize(){
     }
   }
 
-  for (int i = 0; i < rp->fieldNames.size(); i++){
+  for (int i = 0; i < rp->fieldNames.size(); i++) {
     std::ptrdiff_t rpos1 = std::find(rn[i].begin(), rn[i].end(), ((LJoinNode*)prototype)->offset1) - rn[i].begin();
     std::ptrdiff_t rpos2 = std::find(rn[i].begin(), rn[i].end(), ((LJoinNode*)prototype)->offset2) - rn[i].begin();
 
-    if(rpos1 <= rn.size() || rpos1 <= rn.size()){
+    if (rpos1 <= rn.size() || rpos1 <= rn.size()) {
       if (rpos1 < rpos2)
         rpos = rpos1;
       else
@@ -79,26 +79,26 @@ void PJoinNode::Initialize(){
   ValueType vt = lp->fieldTypes[lpos];
 
   for (int i = 0; i < lres.size(); i++)
-    for (int j = 0; j < rres.size(); j++){
+    for (int j = 0; j < rres.size(); j++) {
       bool join = false;
-      if(vt == VT_INT){
-        if((int)lres[i][lpos] == (int)rres[j][rpos]) join = true;
-      }else{
-        if((std::string)lres[i][lpos] == (std::string)rres[j][rpos]) join = true;
+      if (vt == VT_INT) {
+        if ((int)lres[i][lpos] == (int)rres[j][rpos]) join = true;
+      } else {
+        if ((std::string)lres[i][lpos] == (std::string)rres[j][rpos]) join = true;
       }
 
       if (join != true) continue;
 
       std::vector<Value> tmp;
-      for (int k = 0; k < ln.size(); k++){
-        if(k != lpos){
-            tmp.push_back(lres[i][k]);
+      for (int k = 0; k < ln.size(); k++) {
+        if (k != lpos) {
+          tmp.push_back(lres[i][k]);
         }
       }
 
-      for (int k = 0; k < rn.size(); k++){
-        if(k != rpos){
-            tmp.push_back(rres[j][k]);
+      for (int k = 0; k < rn.size(); k++) {
+        if (k != rpos) {
+          tmp.push_back(rres[j][k]);
         }
       }
 
@@ -110,11 +110,11 @@ void PJoinNode::Initialize(){
 
 }
 
-void PJoinNode::Print(int indent){
-  for (int i = 0; i < indent; i++){
+void PJoinNode::Print(int indent) {
+  for (int i = 0; i < indent; i++) {
     std::cout << " ";
   }
-  std::cout << "NL-JOIN: " << ((LJoinNode*)prototype)->offset1 <<"=" << ((LJoinNode*)prototype)->offset2 << std::endl;
+  std::cout << "NL-JOIN: " << ((LJoinNode*)prototype)->offset1 << "=" << ((LJoinNode*)prototype)->offset2 << std::endl;
   left->Print(indent + 2);
   right->Print(indent + 2);
 }

--- a/dbmse/engine/demo/pjoinnode.h
+++ b/dbmse/engine/demo/pjoinnode.h
@@ -28,9 +28,9 @@
 class PJoinNode : public PGetNextNode {
   public:
     PJoinNode(std::unique_ptr<PGetNextNode> left, std::unique_ptr<PGetNextNode> right, LAbstractNode* p);
-    virtual std::vector<std::vector<Value>> GetNext();
-    virtual void Initialize();
-    virtual void Print(int indent);
+    std::vector<std::vector<Value>> GetNext() override;
+    void Initialize() override;
+    void Print(int indent) override;
   private:
     int pos;
 };

--- a/dbmse/engine/demo/pjoinnode.h
+++ b/dbmse/engine/demo/pjoinnode.h
@@ -21,13 +21,13 @@
 #define PJOINNODE_H
 
 #include <vector>
+#include <memory>
 #include "../interface/interface.h"
 #include "pgetnextnode.h"
 
 class PJoinNode : public PGetNextNode {
   public:
-    PJoinNode(PGetNextNode* left, PGetNextNode* right, LAbstractNode* p);
-    ~PJoinNode();
+    PJoinNode(std::unique_ptr<PGetNextNode> left, std::unique_ptr<PGetNextNode> right, LAbstractNode* p);
     virtual std::vector<std::vector<Value>> GetNext();
     virtual void Initialize();
     virtual void Print(int indent);

--- a/dbmse/engine/demo/pjoinnode.h
+++ b/dbmse/engine/demo/pjoinnode.h
@@ -24,7 +24,7 @@
 #include "../interface/interface.h"
 #include "pgetnextnode.h"
 
-class PJoinNode : public PGetNextNode{
+class PJoinNode : public PGetNextNode {
   public:
     PJoinNode(PGetNextNode* left, PGetNextNode* right, LAbstractNode* p);
     ~PJoinNode();

--- a/dbmse/engine/demo/pselectnode.cpp
+++ b/dbmse/engine/demo/pselectnode.cpp
@@ -85,7 +85,7 @@ void PSelectNode::Print(int indent) {
     std::cout << predicate[0];
   else
     std::cout << "NULL" << std::endl;
-  if (left != NULL) left->Print(indent + 2);
-  if (right != NULL) right->Print(indent + 2);
+  if (left != nullptr) left->Print(indent + 2);
+  if (right != nullptr) right->Print(indent + 2);
 }
 

--- a/dbmse/engine/demo/pselectnode.cpp
+++ b/dbmse/engine/demo/pselectnode.cpp
@@ -38,9 +38,6 @@ PSelectNode::PSelectNode(LAbstractNode* p, std::vector<Predicate> predicate): PG
   Initialize();
 }
 
-PSelectNode::~PSelectNode() {
-}
-
 void PSelectNode::Initialize() {
   int val = 0;
   std::string line, word;

--- a/dbmse/engine/demo/pselectnode.cpp
+++ b/dbmse/engine/demo/pselectnode.cpp
@@ -27,9 +27,9 @@
 
 #include "pselectnode.h"
 
-PSelectNode::PSelectNode(){}
+PSelectNode::PSelectNode() {}
 
-PSelectNode::PSelectNode(LAbstractNode* p, std::vector<Predicate> predicate): PGetNextNode(){
+PSelectNode::PSelectNode(LAbstractNode* p, std::vector<Predicate> predicate): PGetNextNode() {
   this->table = ((LSelectNode*)p)->GetBaseTable();
   this->predicate = predicate;
   this->prototype = p;
@@ -38,25 +38,25 @@ PSelectNode::PSelectNode(LAbstractNode* p, std::vector<Predicate> predicate): PG
   Initialize();
 }
 
-PSelectNode::~PSelectNode(){
+PSelectNode::~PSelectNode() {
 }
 
-void PSelectNode::Initialize(){
+void PSelectNode::Initialize() {
   int val = 0;
   std::string line, word;
   std::ifstream f(table.relpath);
-  if(f.is_open()){
+  if (f.is_open()) {
     // skipping first 4 lines
     getline(f, line);
     getline(f, line);
     getline(f, line);
     getline(f, line);
 
-    while(getline(f, line)){
+    while (getline(f, line)) {
       std::vector<Value> tmp;
       std::istringstream iss(line, std::istringstream::in);
       int i = 0;
-      while (iss >> word){
+      while (iss >> word) {
         // Yeah, no predicates :) -- Homework
         Value h;
         if (prototype->fieldTypes[i] == VT_INT)
@@ -72,20 +72,20 @@ void PSelectNode::Initialize(){
   } else std::cout << "Unable to open file";
 }
 
-std::vector<std::vector<Value>> PSelectNode::GetNext(){
+std::vector<std::vector<Value>> PSelectNode::GetNext() {
   return data;
 }
 
-void PSelectNode::Print(int indent){
-  for (int i = 0; i < indent; i++){
-    std::cout<<" ";
+void PSelectNode::Print(int indent) {
+  for (int i = 0; i < indent; i++) {
+    std::cout << " ";
   }
-  std::cout<<"SCAN "<<table.relpath<<" with predicate ";
-  if(predicate.size() != 0)
-    std::cout<<predicate[0];
+  std::cout << "SCAN " << table.relpath << " with predicate ";
+  if (predicate.size() != 0)
+    std::cout << predicate[0];
   else
-    std::cout<<"NULL"<<std::endl;
-  if(left != NULL) left->Print(indent + 2);
-  if(right != NULL) right->Print(indent + 2);
+    std::cout << "NULL" << std::endl;
+  if (left != NULL) left->Print(indent + 2);
+  if (right != NULL) right->Print(indent + 2);
 }
 

--- a/dbmse/engine/demo/pselectnode.h
+++ b/dbmse/engine/demo/pselectnode.h
@@ -28,10 +28,10 @@ class PSelectNode : public PGetNextNode {
   public:
     PSelectNode();
     PSelectNode(LAbstractNode* p, std::vector<Predicate> predicates);
-    virtual std::vector<std::vector<Value>> GetNext();
-    virtual void Initialize();
+    std::vector<std::vector<Value>> GetNext() override;
+    void Initialize() override;
     // print node
-    virtual void Print(int indent);
+    void Print(int indent) override;
   private:
     BaseTable table;
     std::vector<Predicate> predicate;

--- a/dbmse/engine/demo/pselectnode.h
+++ b/dbmse/engine/demo/pselectnode.h
@@ -24,7 +24,7 @@
 #include "../interface/interface.h"
 #include "pgetnextnode.h"
 
-class PSelectNode : public PGetNextNode{
+class PSelectNode : public PGetNextNode {
   public:
     PSelectNode();
     PSelectNode(LAbstractNode* p, std::vector<Predicate> predicates);

--- a/dbmse/engine/demo/pselectnode.h
+++ b/dbmse/engine/demo/pselectnode.h
@@ -28,7 +28,6 @@ class PSelectNode : public PGetNextNode {
   public:
     PSelectNode();
     PSelectNode(LAbstractNode* p, std::vector<Predicate> predicates);
-    ~PSelectNode();
     virtual std::vector<std::vector<Value>> GetNext();
     virtual void Initialize();
     // print node

--- a/dbmse/engine/interface/basics.h
+++ b/dbmse/engine/interface/basics.h
@@ -30,108 +30,112 @@
 
 const int MAXLEN = 1000;
 
-enum ValueType : short{
+enum ValueType : short {
   VT_INT,
   VT_STRING
 };
 
-enum COLUMN_SORT{
-    CS_ASCENDING,
-    CS_DESCENDING,
-    CS_NO,
-    CS_UNKNOWN
+enum COLUMN_SORT {
+  CS_ASCENDING,
+  CS_DESCENDING,
+  CS_NO,
+  CS_UNKNOWN
 };
 
-struct Value{
+struct Value {
   ValueType vtype;
   int vint;
   std::string vstr;
 
-  Value(int v){
+  Value(int v) {
     vtype = VT_INT;
     vint = v;
     vstr = "";
   }
-  Value(std::string v){
+  Value(std::string v) {
     vtype = VT_STRING;
     vstr = v;
   }
-  Value(){
+  Value() {
     vtype = VT_INT;
     vint = 0;
     vstr = "";
   }
-  operator int() const {return vint;}
-  operator std::string() const {return vstr;}
-  ~Value(){
+  operator int() const {
+    return vint;
+  }
+  operator std::string() const {
+    return vstr;
+  }
+  ~Value() {
   }
 };
 
-enum PredicateType{
+enum PredicateType {
   PT_EQUALS,
   PT_GREATERTHAN,
 };
 
-struct Predicate{
+struct Predicate {
   PredicateType ptype;
   ValueType vtype;
   int attribute;
   int vint;
   std::string vstr;
-  Predicate(PredicateType ptype, ValueType vtype, int attribute, int vint, std::string vstr){
+  Predicate(PredicateType ptype, ValueType vtype, int attribute, int vint, std::string vstr) {
     this->ptype = ptype;
     this->vtype = vtype;
     this->attribute = attribute;
     this->vint = vint;
     this->vstr = vstr;
   }
-  Predicate(const Predicate& p){
+  Predicate(const Predicate& p) {
     this->ptype = p.ptype;
     this->vtype = p.vtype;
     this->attribute = p.attribute;
     this->vint = p.vint;
     this->vstr = p.vstr;
   }
-  Predicate(){}
-  ~Predicate(){}
+  Predicate() {}
+  ~Predicate() {}
 };
 
-inline std::ostream& operator<<(std::ostream& stream, const Predicate& p){
+inline std::ostream& operator<<(std::ostream& stream, const Predicate& p) {
   if (p.ptype == PT_EQUALS)
     stream << "x == ";
   else
     stream << "x < ";
 
-  if(p.vtype == VT_INT)
-      stream << p.vint;
-    else
-      stream << p.vstr;
+  if (p.vtype == VT_INT)
+    stream << p.vint;
+  else
+    stream << p.vstr;
   return stream;
 }
 
-struct BaseTable{
+struct BaseTable {
   std::string relpath;
   int nbAttr;
   std::vector<ValueType> vtypes;
   std::vector<std::string> vnames;
   std::vector<COLUMN_SORT> vorders;
-  BaseTable(){}
-  BaseTable(std::string p): relpath(p){
+  BaseTable() {}
+  BaseTable(std::string p): relpath(p) {
     std::string line, word;
     std::ifstream fin(relpath.c_str());
-    if (fin.is_open()){
+    if (fin.is_open()) {
       fin >> nbAttr;
       // names
       getline(fin, line);
       getline(fin, line);
       std::istringstream iss(line, std::istringstream::in);
-      while (iss >> word){
+      while (iss >> word) {
         vnames.push_back(word);
       }
       // types
       getline(fin, line);
       std::istringstream iss2(line, std::istringstream::in);
-      while (iss2 >> word){
+      while (iss2 >> word) {
         if (word == "INT")
           vtypes.push_back(VT_INT);
         else
@@ -140,38 +144,38 @@ struct BaseTable{
       // order
       getline(fin, line);
       std::istringstream iss3(line, std::istringstream::in);
-      while (iss3 >> word){
+      while (iss3 >> word) {
         if (word == "ASCENDING")
           vorders.push_back(CS_ASCENDING);
-        else if(word == "DESCENDING")
+        else if (word == "DESCENDING")
           vorders.push_back(CS_DESCENDING);
-        else if(word == "UNKNOWN")
+        else if (word == "UNKNOWN")
           vorders.push_back(CS_UNKNOWN);
-        else if(word == "UNKNOWN")
+        else if (word == "UNKNOWN")
           vorders.push_back(CS_NO);
       }
 
       fin.close();
     } else std::cout << "Unable to open file";
   }
-  ~BaseTable(){}
+  ~BaseTable() {}
 };
 
-inline std::ostream& operator<<(std::ostream& stream, const BaseTable& bt){
+inline std::ostream& operator<<(std::ostream& stream, const BaseTable& bt) {
   stream << "located in " << bt.relpath << " having " << bt.nbAttr << " following attributes:" << std::endl;
-  for(int i = 0; i < bt.nbAttr; i++){
-    stream << i <<". " << bt.vnames[i] << " ";
+  for (int i = 0; i < bt.nbAttr; i++) {
+    stream << i << ". " << bt.vnames[i] << " ";
     if (bt.vtypes[i] == VT_INT)
       stream << "INT ";
     else
       stream << "STR ";
-    if (bt.vorders[i] == CS_ASCENDING )
+    if (bt.vorders[i] == CS_ASCENDING)
       stream << "ASCENDING";
-    else if(bt.vorders[i] == CS_DESCENDING)
+    else if (bt.vorders[i] == CS_DESCENDING)
       stream << "DESCENDING";
-    else if(bt.vorders[i] == CS_UNKNOWN)
+    else if (bt.vorders[i] == CS_UNKNOWN)
       stream << "UNKNOWN";
-    else if(bt.vorders[i] == CS_NO)
+    else if (bt.vorders[i] == CS_NO)
       stream << "UNSORTED";
     stream << std::endl;
   }
@@ -179,7 +183,7 @@ inline std::ostream& operator<<(std::ostream& stream, const BaseTable& bt){
 }
 
 
-enum ErrCode{
+enum ErrCode {
   EC_OK,
   EC_FINISH,
   EC_ERROR

--- a/dbmse/engine/interface/interface.cpp
+++ b/dbmse/engine/interface/interface.cpp
@@ -153,10 +153,8 @@ LUniqueNode::LUniqueNode(std::unique_ptr<LAbstractNode> child_): LAbstractNode(s
 
 /* Physical nodes*/
 
-PResultNode::PResultNode(PResultNode* left, PResultNode* right, LAbstractNode* p) {
-  this->left = left;
-  this->right = right;
-  this->prototype = p;
+PResultNode::PResultNode(std::unique_ptr<PResultNode> left_, std::unique_ptr<PResultNode> right_, LAbstractNode* p)
+  : left(std::move(left_)), right(std::move(right_)), prototype(p) {
   pos = 0;
 }
 

--- a/dbmse/engine/interface/interface.cpp
+++ b/dbmse/engine/interface/interface.cpp
@@ -22,24 +22,24 @@
 #include <string.h>
 #include "interface.h"
 
-LAbstractNode::LAbstractNode(LAbstractNode* left, LAbstractNode* right){
+LAbstractNode::LAbstractNode(LAbstractNode* left, LAbstractNode* right) {
   this->left = left;
   this->right = right;
 }
 
-LAbstractNode::~LAbstractNode(){
+LAbstractNode::~LAbstractNode() {
 }
 
-LAbstractNode* LAbstractNode::GetLeft(){
+LAbstractNode* LAbstractNode::GetLeft() {
   return left;
 }
 
-LAbstractNode* LAbstractNode::GetRight(){
+LAbstractNode* LAbstractNode::GetRight() {
   return right;
 }
 
 LJoinNode::LJoinNode(LAbstractNode* left, LAbstractNode* right,
-                     std::string offset1, std::string offset2, int memorylimit):LAbstractNode(left, right){
+                     std::string offset1, std::string offset2, int memorylimit): LAbstractNode(left, right) {
   this->offset1 = offset1;
   this->offset2 = offset2;
   this->memorylimit = memorylimit;
@@ -48,21 +48,20 @@ LJoinNode::LJoinNode(LAbstractNode* left, LAbstractNode* right,
   std::vector<std::string> match;
   ValueType vt;
   COLUMN_SORT cs;
-  for (int i = 0; i < left->fieldNames.size(); i++){
-    for (int j = 0; j < right->fieldNames.size(); j++){
+  for (int i = 0; i < left->fieldNames.size(); i++) {
+    for (int j = 0; j < right->fieldNames.size(); j++) {
       std::vector<std::string> l = left->fieldNames[i];
       std::vector<std::string> r = right->fieldNames[j];
 
-      if(std::find(l.begin(), l.end(), offset1) != l.end()){
-        if(std::find(r.begin(), r.end(), offset2) != r.end()){
+      if (std::find(l.begin(), l.end(), offset1) != l.end()) {
+        if (std::find(r.begin(), r.end(), offset2) != r.end()) {
           match = l;
           match.insert(std::end(match), std::begin(r), std::end(r));
           vt = left->fieldTypes[i];
           cs = left->fieldOrders[i];
         }
-      } else
-      if(std::find(l.begin(), l.end(), offset2) != l.end()){
-        if(std::find(r.begin(), r.end(), offset1) != r.end()){
+      } else if (std::find(l.begin(), l.end(), offset2) != l.end()) {
+        if (std::find(r.begin(), r.end(), offset1) != r.end()) {
           match = l;
           match.insert(std::end(match), std::begin(r), std::end(r));
           vt = left->fieldTypes[i];
@@ -72,20 +71,20 @@ LJoinNode::LJoinNode(LAbstractNode* left, LAbstractNode* right,
     }
   }
 
-  for (int i = 0; i < left->fieldNames.size(); i++){
+  for (int i = 0; i < left->fieldNames.size(); i++) {
     std::vector<std::string> l = left->fieldNames[i];
-    if(std::find(l.begin(), l.end(), offset1) == l.end())
-      if(std::find(l.begin(), l.end(), offset2) == l.end()){
+    if (std::find(l.begin(), l.end(), offset1) == l.end())
+      if (std::find(l.begin(), l.end(), offset2) == l.end()) {
         fieldNames.push_back(l);
         fieldTypes.push_back(left->fieldTypes[i]);
         fieldOrders.push_back(left->fieldOrders[i]);
       }
   }
 
-  for (int i = 0; i < right->fieldNames.size(); i++){
+  for (int i = 0; i < right->fieldNames.size(); i++) {
     std::vector<std::string> r = right->fieldNames[i];
-    if(std::find(r.begin(), r.end(), offset1) == r.end())
-      if(std::find(r.begin(), r.end(), offset2) == r.end()){
+    if (std::find(r.begin(), r.end(), offset1) == r.end())
+      if (std::find(r.begin(), r.end(), offset2) == r.end()) {
         fieldNames.push_back(r);
         fieldTypes.push_back(right->fieldTypes[i]);
         fieldOrders.push_back(right->fieldOrders[i]);
@@ -99,17 +98,17 @@ LJoinNode::LJoinNode(LAbstractNode* left, LAbstractNode* right,
 
 }
 
-LJoinNode::~LJoinNode(){
+LJoinNode::~LJoinNode() {
   delete left;
   delete right;
 }
 
-LProjectNode::LProjectNode(LAbstractNode* child, std::vector<std::string> tokeep):LAbstractNode(child, NULL){
-  for (int i = 0; i < left->fieldNames.size(); i++){
-    for (int j = 0; j < tokeep.size(); j++){
+LProjectNode::LProjectNode(LAbstractNode* child, std::vector<std::string> tokeep): LAbstractNode(child, NULL) {
+  for (int i = 0; i < left->fieldNames.size(); i++) {
+    for (int j = 0; j < tokeep.size(); j++) {
       std::vector<std::string> source = left->fieldNames[i];
       std::string candidate = tokeep[j];
-      if(std::find(source.begin(), source.end(), candidate) != source.end()){
+      if (std::find(source.begin(), source.end(), candidate) != source.end()) {
         fieldNames.push_back(source);
         fieldTypes.push_back(left->fieldTypes[i]);
         fieldOrders.push_back(left->fieldOrders[i]);
@@ -119,16 +118,16 @@ LProjectNode::LProjectNode(LAbstractNode* child, std::vector<std::string> tokeep
   }
 }
 
-LProjectNode::~LProjectNode(){
+LProjectNode::~LProjectNode() {
   delete left;
 }
 
 LSelectNode::LSelectNode(BaseTable& table,
-                         std::vector<Predicate> predicates): LAbstractNode(NULL, NULL){
+                         std::vector<Predicate> predicates): LAbstractNode(NULL, NULL) {
   this->table = table;
   this->predicates = predicates;
   iteratorpos = 0;
-  for (int i = 0; i < table.nbAttr; i++){
+  for (int i = 0; i < table.nbAttr; i++) {
     std::string tmp = table.relpath + "." + table.vnames[i];
     std::vector<std::string> tmp2;
     tmp2.push_back(tmp);
@@ -138,48 +137,48 @@ LSelectNode::LSelectNode(BaseTable& table,
   fieldOrders = table.vorders;
 }
 
-BaseTable& LSelectNode::GetBaseTable(){
+BaseTable& LSelectNode::GetBaseTable() {
   return table;
 }
 
-std::tuple<int, Predicate> LSelectNode::GetNextPredicate(){
-  if(predicates.size() == 0 || iteratorpos >= predicates.size()){
-      return std::make_tuple(1, Predicate());
+std::tuple<int, Predicate> LSelectNode::GetNextPredicate() {
+  if (predicates.size() == 0 || iteratorpos >= predicates.size()) {
+    return std::make_tuple(1, Predicate());
   }
   return std::make_tuple(0, predicates[iteratorpos++]);
 }
 
-void LSelectNode::ResetIterator(){
+void LSelectNode::ResetIterator() {
   iteratorpos = 0;
 }
 
 
-LSelectNode::~LSelectNode(){
+LSelectNode::~LSelectNode() {
 }
 
-LUniqueNode::LUniqueNode(LAbstractNode* child):LAbstractNode(child, NULL){
+LUniqueNode::LUniqueNode(LAbstractNode* child): LAbstractNode(child, NULL) {
 }
 
-LUniqueNode::~LUniqueNode(){
+LUniqueNode::~LUniqueNode() {
 }
 
 
 /* Physical nodes*/
 
-PResultNode::PResultNode(PResultNode* left, PResultNode* right, LAbstractNode* p){
+PResultNode::PResultNode(PResultNode* left, PResultNode* right, LAbstractNode* p) {
   this->left = left;
   this->right = right;
   this->prototype = p;
   pos = 0;
 }
 
-PResultNode::~PResultNode(){
+PResultNode::~PResultNode() {
 }
 
-std::tuple<ErrCode, std::vector<Value>> PResultNode::GetRecord(){
+std::tuple<ErrCode, std::vector<Value>> PResultNode::GetRecord() {
   std::vector<Value> vals;
   if (pos == data.size()) return std::make_tuple(EC_FINISH, vals);
-  for(int i = 0; i < GetAttrNum(); i++){
+  for (int i = 0; i < GetAttrNum(); i++) {
     vals.push_back(data[pos][i]);
   }
   pos++;

--- a/dbmse/engine/interface/interface.cpp
+++ b/dbmse/engine/interface/interface.cpp
@@ -24,7 +24,7 @@
 
 LAbstractNode::LAbstractNode(LAbstractNode* left, LAbstractNode* right){
   this->left = left;
-  this->rigth = right;
+  this->right = right;
 }
 
 LAbstractNode::~LAbstractNode(){
@@ -35,7 +35,7 @@ LAbstractNode* LAbstractNode::GetLeft(){
 }
 
 LAbstractNode* LAbstractNode::GetRight(){
-  return rigth;
+  return right;
 }
 
 LJoinNode::LJoinNode(LAbstractNode* left, LAbstractNode* right,
@@ -101,7 +101,7 @@ LJoinNode::LJoinNode(LAbstractNode* left, LAbstractNode* right,
 
 LJoinNode::~LJoinNode(){
   delete left;
-  delete rigth;
+  delete right;
 }
 
 LProjectNode::LProjectNode(LAbstractNode* child, std::vector<std::string> tokeep):LAbstractNode(child, NULL){

--- a/dbmse/engine/interface/interface.cpp
+++ b/dbmse/engine/interface/interface.cpp
@@ -19,27 +19,29 @@
 
 #include <algorithm>
 #include <tuple>
+#include <utility>
 #include <string.h>
 #include "interface.h"
 
-LAbstractNode::LAbstractNode(LAbstractNode* left, LAbstractNode* right) {
-  this->left = left;
-  this->right = right;
+
+LAbstractNode::LAbstractNode(std::unique_ptr<LAbstractNode> left_, std::unique_ptr<LAbstractNode> right_)
+  : left(std::move(left_)), right(std::move(right_)) {
 }
 
 LAbstractNode::~LAbstractNode() {
 }
 
 LAbstractNode* LAbstractNode::GetLeft() {
-  return left;
+  return left.get();
 }
 
 LAbstractNode* LAbstractNode::GetRight() {
-  return right;
+  return right.get();
 }
 
-LJoinNode::LJoinNode(LAbstractNode* left, LAbstractNode* right,
-                     std::string offset1, std::string offset2, int memorylimit): LAbstractNode(left, right) {
+LJoinNode::LJoinNode(std::unique_ptr<LAbstractNode> left_, std::unique_ptr<LAbstractNode> right_,
+                     std::string offset1, std::string offset2, int memorylimit)
+  : LAbstractNode(std::move(left_), std::move(right_)) {
   this->offset1 = offset1;
   this->offset2 = offset2;
   this->memorylimit = memorylimit;
@@ -98,12 +100,8 @@ LJoinNode::LJoinNode(LAbstractNode* left, LAbstractNode* right,
 
 }
 
-LJoinNode::~LJoinNode() {
-  delete left;
-  delete right;
-}
-
-LProjectNode::LProjectNode(LAbstractNode* child, std::vector<std::string> tokeep): LAbstractNode(child, NULL) {
+LProjectNode::LProjectNode(std::unique_ptr<LAbstractNode> child_, std::vector<std::string> tokeep)
+  : LAbstractNode(std::move(child_), nullptr) {
   for (int i = 0; i < left->fieldNames.size(); i++) {
     for (int j = 0; j < tokeep.size(); j++) {
       std::vector<std::string> source = left->fieldNames[i];
@@ -118,12 +116,8 @@ LProjectNode::LProjectNode(LAbstractNode* child, std::vector<std::string> tokeep
   }
 }
 
-LProjectNode::~LProjectNode() {
-  delete left;
-}
-
 LSelectNode::LSelectNode(BaseTable& table,
-                         std::vector<Predicate> predicates): LAbstractNode(NULL, NULL) {
+                         std::vector<Predicate> predicates): LAbstractNode(nullptr, nullptr) {
   this->table = table;
   this->predicates = predicates;
   iteratorpos = 0;
@@ -153,13 +147,7 @@ void LSelectNode::ResetIterator() {
 }
 
 
-LSelectNode::~LSelectNode() {
-}
-
-LUniqueNode::LUniqueNode(LAbstractNode* child): LAbstractNode(child, NULL) {
-}
-
-LUniqueNode::~LUniqueNode() {
+LUniqueNode::LUniqueNode(std::unique_ptr<LAbstractNode> child_): LAbstractNode(std::move(child_), nullptr) {
 }
 
 

--- a/dbmse/engine/interface/interface.h
+++ b/dbmse/engine/interface/interface.h
@@ -42,7 +42,7 @@ class LAbstractNode{
     std::vector<COLUMN_SORT> fieldOrders;
   protected:
     LAbstractNode* left;
-    LAbstractNode* rigth;
+    LAbstractNode* right;
 };
 
 class LCrossProductNode : public LAbstractNode{

--- a/dbmse/engine/interface/interface.h
+++ b/dbmse/engine/interface/interface.h
@@ -30,7 +30,7 @@
 
 /* Logical nodes (query) */
 
-class LAbstractNode{
+class LAbstractNode {
   public:
     LAbstractNode(LAbstractNode* left, LAbstractNode* right);
     virtual ~LAbstractNode();
@@ -45,13 +45,13 @@ class LAbstractNode{
     LAbstractNode* right;
 };
 
-class LCrossProductNode : public LAbstractNode{
+class LCrossProductNode : public LAbstractNode {
   public:
     LCrossProductNode(LAbstractNode* left, LAbstractNode* right);
     ~LCrossProductNode();
 };
 
-class LJoinNode : public LAbstractNode{
+class LJoinNode : public LAbstractNode {
   public:
     // offsets are defined as "TableName.AttributeName" so, ensure there is no duplicates
     LJoinNode(LAbstractNode* left, LAbstractNode* right, std::string offset1, std::string offset2, int memorylimit);
@@ -62,7 +62,7 @@ class LJoinNode : public LAbstractNode{
     int memorylimit;
 };
 
-class LProjectNode : public LAbstractNode{
+class LProjectNode : public LAbstractNode {
   public:
     // offsets to keep
     LProjectNode(LAbstractNode* child, std::vector<std::string> tokeep);
@@ -71,7 +71,7 @@ class LProjectNode : public LAbstractNode{
     std::vector<std::string> offsets;
 };
 
-class LSelectNode : public LAbstractNode{
+class LSelectNode : public LAbstractNode {
   public:
     LSelectNode(BaseTable& table, std::vector<Predicate> predicates);
     // returns a reference to BaseTable
@@ -87,7 +87,7 @@ class LSelectNode : public LAbstractNode{
     BaseTable table;
 };
 
-class LUniqueNode : public LAbstractNode{
+class LUniqueNode : public LAbstractNode {
   public:
     LUniqueNode(LAbstractNode* child);
     ~LUniqueNode();
@@ -95,7 +95,7 @@ class LUniqueNode : public LAbstractNode{
 
 // Physical node interface (result), should be used for automatic testing
 
-class PResultNode{
+class PResultNode {
   public:
     PResultNode(PResultNode* left, PResultNode* right, LAbstractNode* p);
     virtual ~PResultNode();

--- a/dbmse/engine/interface/interface.h
+++ b/dbmse/engine/interface/interface.h
@@ -93,7 +93,7 @@ class LUniqueNode : public LAbstractNode {
 
 class PResultNode {
   public:
-    PResultNode(PResultNode* left, PResultNode* right, LAbstractNode* p);
+    PResultNode(std::unique_ptr<PResultNode> left, std::unique_ptr<PResultNode> right, LAbstractNode* p);
     virtual ~PResultNode();
     // returns number of attributes
     virtual int GetAttrNum() = 0;
@@ -104,8 +104,8 @@ class PResultNode {
     // returns error status and data, if possible
     virtual std::tuple<ErrCode, std::vector<Value>> GetRecord();
   protected:
-    PResultNode* left;
-    PResultNode* right;
+    std::unique_ptr<PResultNode> left;
+    std::unique_ptr<PResultNode> right;
     std::vector<std::vector<Value>> data;
     int pos;
 };

--- a/dbmse/engine/interface/interface.h
+++ b/dbmse/engine/interface/interface.h
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <memory>
 
 #include "basics.h"
 
@@ -32,7 +33,7 @@
 
 class LAbstractNode {
   public:
-    LAbstractNode(LAbstractNode* left, LAbstractNode* right);
+    LAbstractNode(std::unique_ptr<LAbstractNode> left, std::unique_ptr<LAbstractNode> right);
     virtual ~LAbstractNode();
     LAbstractNode* GetLeft();
     LAbstractNode* GetRight();
@@ -41,21 +42,19 @@ class LAbstractNode {
     std::vector<ValueType> fieldTypes;
     std::vector<COLUMN_SORT> fieldOrders;
   protected:
-    LAbstractNode* left;
-    LAbstractNode* right;
+    std::unique_ptr<LAbstractNode> left;
+    std::unique_ptr<LAbstractNode> right;
 };
 
 class LCrossProductNode : public LAbstractNode {
   public:
-    LCrossProductNode(LAbstractNode* left, LAbstractNode* right);
-    ~LCrossProductNode();
+    LCrossProductNode(std::unique_ptr<LAbstractNode> left, std::unique_ptr<LAbstractNode> right);
 };
 
 class LJoinNode : public LAbstractNode {
   public:
     // offsets are defined as "TableName.AttributeName" so, ensure there is no duplicates
-    LJoinNode(LAbstractNode* left, LAbstractNode* right, std::string offset1, std::string offset2, int memorylimit);
-    ~LJoinNode();
+    LJoinNode(std::unique_ptr<LAbstractNode> left, std::unique_ptr<LAbstractNode> right, std::string offset1, std::string offset2, int memorylimit);
     // attributes to perform equi-join on
     std::string offset1, offset2;
     // maximum number of records permitted to present inside physical node
@@ -65,8 +64,7 @@ class LJoinNode : public LAbstractNode {
 class LProjectNode : public LAbstractNode {
   public:
     // offsets to keep
-    LProjectNode(LAbstractNode* child, std::vector<std::string> tokeep);
-    ~LProjectNode();
+    LProjectNode(std::unique_ptr<LAbstractNode> child, std::vector<std::string> tokeep);
     // offsets are defined as "TableName.AttributeName" so, ensure there is no duplicates
     std::vector<std::string> offsets;
 };
@@ -80,7 +78,6 @@ class LSelectNode : public LAbstractNode {
     std::tuple<int, Predicate> GetNextPredicate();
     // resets predicate iterator
     void ResetIterator();
-    ~LSelectNode();
   private:
     int iteratorpos;
     std::vector<Predicate> predicates;
@@ -89,8 +86,7 @@ class LSelectNode : public LAbstractNode {
 
 class LUniqueNode : public LAbstractNode {
   public:
-    LUniqueNode(LAbstractNode* child);
-    ~LUniqueNode();
+    LUniqueNode(std::unique_ptr<LAbstractNode> child);
 };
 
 // Physical node interface (result), should be used for automatic testing

--- a/dbmse/style.astylerc
+++ b/dbmse/style.astylerc
@@ -1,0 +1,9 @@
+--style=java
+--indent=spaces=2
+--indent-classes
+--align-pointer=type
+--align-reference=type
+--pad-oper
+--pad-comma
+--pad-header
+--convert-tabs


### PR DESCRIPTION
This PR is based on #3, which is scheduled to be merged after the course ends. I believe this PR's fate is going to be similar.

Things done:

* Replace pure pointers with `std::unique_ptr`. If C++14 is allowed, some boilerplate can be replaced with `std::make_unique`. This also enables the full power of RAII and removes a lot of destructors.
* Replace `NULL` with `nullptr`.
* Mark overrides of virtual functions with `override` keyword instead of `virtual` (`override` implies `virtual`).

Things that can be improved:
* Better use of move semantics. E.g. `LSelectNode(BaseTable& table, std::vector<Predicate> predicates);` always copies its second argument, even if it's a temporary value. If one replaces `this->predicates = predicates;` with `this->predicates = std::move(predicates);`, it will use move instead of copy in these situations.